### PR TITLE
Refactor path loading for offline use

### DIFF
--- a/2d_feature_extraction/configs/scannet200_eval.yaml
+++ b/2d_feature_extraction/configs/scannet200_eval.yaml
@@ -27,7 +27,7 @@ openmask3d:
 external:
   sam_checkpoint: '${env:CKPT_SAM}'
   sam_model_type: 'vit_h'
-  clip_model: 'ViT-L/14@336px'
+  clip_model: '${env:CKPT_CLIP336}'
 
 output:
   experiment_name: 'experiment'

--- a/2d_feature_extraction/get_2D_features.py
+++ b/2d_feature_extraction/get_2D_features.py
@@ -5,7 +5,7 @@ from data.load import Camera, InstanceMasks3D, Images, PointCloud, get_number_of
 from utils import get_free_gpu, create_out_folder
 from mask_features_computation.features_extractor import FeaturesExtractor
 import torch
-import paths
+from paths import FEATS2D_DIR
 import os
 from glob import glob
 
@@ -16,7 +16,7 @@ def main(ctx: DictConfig):
     # device = get_free_gpu(7000) if torch.cuda.is_available() else device
     device = "cuda:0"
     print(f"[INFO] Using device: {device}")
-    out_folder = ctx.output.output_directory
+    out_folder = ctx.output.output_directory or str(FEATS2D_DIR)
     os.chdir(hydra.utils.get_original_cwd())
     if not os.path.exists(out_folder):
         os.makedirs(out_folder)

--- a/3d_feature_extraction/get_3D_features.py
+++ b/3d_feature_extraction/get_3D_features.py
@@ -3,7 +3,7 @@ import math
 import time
 import wandb
 from pathlib import Path
-from paths import SCANNET_PROC, FEATS3D_DIR
+from paths import SCANNET_PROC, FEATS3D_DIR, CKPT_CLIP_EVA02, TIMM_EVA_GIANT
 
 import torch.cuda.amp as amp
 import torch.nn.parallel
@@ -60,6 +60,11 @@ def compute_embedding(clip_model, texts, image):
 
 def main(args):
     args, ds_init = parse_args(args)
+
+    if not args.pretrained:
+        args.pretrained = str(CKPT_CLIP_EVA02)
+    if not getattr(args, 'pretrained_pc', None):
+        args.pretrained_pc = str(TIMM_EVA_GIANT)
 
     global best_acc1
 

--- a/3d_feature_extraction/get_3D_proposals.py
+++ b/3d_feature_extraction/get_3D_proposals.py
@@ -1,6 +1,6 @@
 import logging
 import os
-import paths
+from paths import CKPT_MASK3D, SCANNET_PROC, MASKS_DIR
 import hydra
 from dotenv import load_dotenv
 from omegaconf import DictConfig
@@ -37,8 +37,15 @@ def get_parameters(cfg: DictConfig):
 
 @hydra.main(config_path="conf", config_name="config_base_class_agn_masks_scannet200.yaml")
 def get_class_agnostic_masks_scannet200(cfg: DictConfig):
-   
+
     os.chdir(hydra.utils.get_original_cwd())
+    if cfg.general.checkpoint is None:
+        cfg.general.checkpoint = str(CKPT_MASK3D)
+    if cfg.general.mask_save_dir is None:
+        cfg.general.mask_save_dir = str(MASKS_DIR)
+    cfg.data.test_dataset.data_dir = str(SCANNET_PROC)
+    cfg.data.validation_dataset.data_dir = str(SCANNET_PROC)
+    cfg.data.train_dataset.data_dir = str(SCANNET_PROC)
     cfg, model, _ = get_parameters(cfg)
     test_dataset = hydra.utils.instantiate(cfg.data.test_dataset)
     c_fn = hydra.utils.instantiate(cfg.data.test_collation)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Despite encouraging progress in 3D scene understanding, it remains challenging t
   conda activate inst3d-lmm # activate it
   bash requirements.sh # installation requirements
   pip install -e . # install current repository in editable mode
-  python -m paths  # create folder structure
+  python -m paths --mk  # create folder structure
   ```
   
 - Download LLM and other foundation models backbone:

--- a/paths.py
+++ b/paths.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import argparse
 
 ROOT = Path(__file__).resolve().parent
 
@@ -9,7 +10,9 @@ OUTPUT_ROOT = ROOT / "outputs"
 CKPT_MASK3D = WEIGHTS_ROOT / "mask3d" / "scannet200_val.ckpt"
 CKPT_UNI3D = WEIGHTS_ROOT / "uni3d" / "uni3d_g.pth"
 CKPT_CLIP_EVA02 = WEIGHTS_ROOT / "clip" / "EVA02-E-14-plus" / "open_clip_pytorch_model.bin"
+TIMM_EVA_GIANT = WEIGHTS_ROOT / "timm" / "eva_giant_patch14_560" / "model.bin"
 CKPT_SAM = WEIGHTS_ROOT / "sam" / "sam_vit_h_4b8939.pth"
+CKPT_CLIP336 = WEIGHTS_ROOT / "clip" / "clip-vit-large-patch14-336" / "pytorch_model.bin"
 CKPT_VICUNA = WEIGHTS_ROOT / "llm" / "vicuna-7b-v1.5"
 
 SCANS_PATH = DATASETS_ROOT / "scannetv2_frames"
@@ -21,8 +24,31 @@ ANNO_ROOT = DATASETS_ROOT / "annotations"
 
 
 def main():
-    for p in [WEIGHTS_ROOT, DATASETS_ROOT, OUTPUT_ROOT, MASKS_DIR, FEATS3D_DIR, FEATS2D_DIR, ANNO_ROOT]:
-        Path(p).mkdir(parents=True, exist_ok=True)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mk", action="store_true", help="create folder structure")
+    args = parser.parse_args()
+
+    if args.mk:
+        dirs = [
+            WEIGHTS_ROOT,
+            DATASETS_ROOT,
+            OUTPUT_ROOT,
+            MASKS_DIR,
+            FEATS3D_DIR,
+            FEATS2D_DIR,
+            ANNO_ROOT,
+            SCANS_PATH,
+            SCANNET_PROC,
+            CKPT_MASK3D.parent,
+            CKPT_UNI3D.parent,
+            CKPT_CLIP_EVA02.parent,
+            TIMM_EVA_GIANT.parent,
+            CKPT_SAM.parent,
+            CKPT_CLIP336.parent,
+            CKPT_VICUNA,
+        ]
+        for p in dirs:
+            Path(p).mkdir(parents=True, exist_ok=True)
 
 
 if __name__ == "__main__":

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,5 +1,12 @@
 # ========================= data ==========================
-from paths import ANNO_ROOT, CKPT_VICUNA, CKPT_CLIP_EVA02, CKPT_SAM
+from paths import (
+    ANNO_ROOT,
+    CKPT_VICUNA,
+    CKPT_CLIP_EVA02,
+    TIMM_EVA_GIANT,
+    CKPT_CLIP336,
+    CKPT_SAM,
+)
 
 anno_root = str(ANNO_ROOT)  # annotation dir
 pc_encoder = "uni3d" # or ulip2

--- a/scripts/export_paths.sh
+++ b/scripts/export_paths.sh
@@ -15,6 +15,11 @@ import paths
 print(paths.CKPT_CLIP_EVA02)
 PY
 )
+export TIMM_EVA_GIANT=$(python - <<'PY'
+import paths
+print(paths.TIMM_EVA_GIANT)
+PY
+)
 export CKPT_SAM=$(python - <<'PY'
 import paths
 print(paths.CKPT_SAM)
@@ -48,6 +53,11 @@ PY
 export FEATS2D_DIR=$(python - <<'PY'
 import paths
 print(paths.FEATS2D_DIR)
+PY
+)
+export CKPT_CLIP336=$(python - <<'PY'
+import paths
+print(paths.CKPT_CLIP336)
 PY
 )
 export OUTPUT_ROOT=$(python - <<'PY'

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,3 +1,5 @@
+import os, sys, subprocess
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import paths
 from pathlib import Path
 
@@ -8,7 +10,9 @@ ALL_PATHS = [
     paths.CKPT_MASK3D,
     paths.CKPT_UNI3D,
     paths.CKPT_CLIP_EVA02,
+    paths.TIMM_EVA_GIANT,
     paths.CKPT_SAM,
+    paths.CKPT_CLIP336,
     paths.CKPT_VICUNA,
     paths.SCANS_PATH,
     paths.SCANNET_PROC,
@@ -19,5 +23,6 @@ ALL_PATHS = [
 ]
 
 def test_paths_exist_call():
+    subprocess.run([sys.executable, "-m", "paths", "--mk"], check=True)
     for p in ALL_PATHS:
-        Path(p).exists()
+        assert Path(p).exists()


### PR DESCRIPTION
## Summary
- centralize all weight and dataset paths in `paths.py`
- update Hydra config to load models from environment paths
- ensure feature extraction scripts use local checkpoints
- export new environment variables for paths
- add directory creation helper via `python -m paths --mk`
- test that all configured paths exist

## Testing
- `shellcheck scripts/export_paths.sh scripts/3d_feature_extraction.sh scripts/2d_feature_extraction.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f1dfc1748330809b418910ed8fdd